### PR TITLE
Reduce memory usage of tolerance calculation of interpolate_measures (+CI and tests)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,29 @@
+name: Tests
+
+on:
+  push:
+    branches: [main, master]
+  pull_request:
+    branches: [main, master]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: ["3.10", "3.12"]
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      - name: Install package and test dependencies
+        run: |
+          pip install -e .
+          pip install pytest
+
+      - name: Run tests
+        run: python -m pytest test/ -v

--- a/.gitignore
+++ b/.gitignore
@@ -23,6 +23,7 @@ wheels/
 *.egg-info/
 .installed.cfg
 *.egg
+uv.lock
 MANIFEST
 
 # PyInstaller

--- a/README.rst
+++ b/README.rst
@@ -31,6 +31,17 @@ See the `Phonlab Workshop slide deck <https://docs.google.com/presentation/d/1gf
 
 See also the `examples` folder in the github repository!
 
+=======
+Testing
+=======
+
+To run the unit tests:
+
+.. code-block::
+
+  pip install pytest
+  python -m pytest test/ -v
+
 ============
 Contributing
 ============

--- a/phonlab/utils/tidy.py
+++ b/phonlab/utils/tidy.py
@@ -937,17 +937,21 @@ formants dataframe and adds measurements at the desired observation times in the
     tol = np.mean(np.diff(meas_ts)) / 2 if tol is None else tol
     # An interpolation timepoint is out of tolerance if its minimum absolute
     # distance to a measurement timepoint is greater than `tol`
-    outoftol = np.min(
-        np.abs(
-            np.expand_dims(meas_ts, axis=0) - np.expand_dims(interp_ts, axis=1)
-        ),
-        axis=1
-    ) > tol
+    meas_vals = np.asarray(meas_ts)
+    interp_vals = np.asarray(interp_ts)
+    idx = np.searchsorted(meas_vals, interp_vals)
+    idx_right = np.clip(idx, 0, len(meas_vals) - 1)
+    idx_left = np.clip(idx - 1, 0, len(meas_vals) - 1)
+    nearest_dist = np.minimum(
+        np.abs(meas_vals[idx_right] - interp_vals),
+        np.abs(meas_vals[idx_left] - interp_vals),
+    )
+    outoftol = nearest_dist > tol
     try:
         assert(not outoftol.any())
     except AssertionError:
         with np.printoptions(threshold=3):
-            msg = f'The maximum distance allowed from an interpolation timepoint to the nearest measurement timepoint is {tol}, and that tolerance is exceeded at interpolation timepoint(s) {interp_ts[outoftol].values}. Use the `tol` param to adjust the tolerance or exclude these interpolation timepoint(s).'
+            msg = f'The maximum distance allowed from an interpolation timepoint to the nearest measurement timepoint is {tol}, and that tolerance is exceeded at interpolation timepoint(s) {np.asarray(interp_ts[outoftol])}. Use the `tol` param to adjust the tolerance or exclude these interpolation timepoint(s).'
         raise ValueError(msg) from None
     try:
         assert(np.all(np.diff(meas_ts) > 0))
@@ -956,7 +960,7 @@ formants dataframe and adds measurements at the desired observation times in the
         raise ValueError(msg) from None
     meas_cols = [c for c in meas_df.columns if c != meas_ts.name]
     try:
-        if not overwrite:
+        if not overwrite and interp_df is not None:
             overlaps = set(interp_df.columns) & set(meas_cols)
             assert(len(overlaps) == 0)
     except AssertionError:

--- a/test/test_interpolate_measures.py
+++ b/test/test_interpolate_measures.py
@@ -1,0 +1,183 @@
+"""Tests for phonlab.interpolate_measures."""
+
+import numpy as np
+import pandas as pd
+import pytest
+
+from phonlab.utils.tidy import interpolate_measures
+
+
+def _make_meas_df(start=0.0, stop=1.0, step=0.01, cols=("F1", "F2")):
+    """Create a simple measurement dataframe with known linear columns."""
+    ts = np.arange(start, stop + step / 2, step)
+    data = {"sec": ts}
+    for i, col in enumerate(cols, start=1):
+        data[col] = ts * i  # perfectly linear: F1 = t, F2 = 2t, ...
+    return pd.DataFrame(data)
+
+
+def test_basic_interpolation():
+    """Linearly interpolated values are correct."""
+    meas = _make_meas_df()
+    interp_times = np.array([0.02, 0.05, 0.08])
+    result = interpolate_measures(
+        meas_df=meas, meas_ts="sec", interp_ts=interp_times
+    )
+    np.testing.assert_allclose(result["F1"], interp_times, atol=1e-10)
+    np.testing.assert_allclose(result["F2"], interp_times * 2, atol=1e-10)
+
+
+def test_with_interp_df():
+    """Results merge into the input dataframe."""
+    meas = _make_meas_df()
+    interp_df = pd.DataFrame({"obs_t": [0.1, 0.2, 0.3], "label": ["a", "b", "c"]})
+    result = interpolate_measures(
+        meas_df=meas, meas_ts="sec", interp_df=interp_df, interp_ts="obs_t"
+    )
+    assert "label" in result.columns
+    assert "F1" in result.columns
+    assert "F2" in result.columns
+    np.testing.assert_allclose(result["F1"], [0.1, 0.2, 0.3], atol=1e-10)
+
+
+def test_without_interp_df_returns_standalone():
+    """Returns standalone dataframe from array input."""
+    meas = _make_meas_df()
+    interp_times = np.array([0.05, 0.15])
+    result = interpolate_measures(
+        meas_df=meas, meas_ts="sec", interp_ts=interp_times
+    )
+    assert "tcol" in result.columns
+    assert len(result) == 2
+
+
+def test_default_tolerance():
+    """Default tol is auto-computed as half the measurement timestep."""
+    meas = _make_meas_df(step=0.01)  # step=0.01 → tol=0.005
+    interp_times = np.array([0.013])  # 0.003 from nearest, within tol
+    result = interpolate_measures(
+        meas_df=meas, meas_ts="sec", interp_ts=interp_times
+    )
+    assert len(result) == 1
+
+
+def test_out_of_range_raises():
+    """Interp points beyond measurement range + tol raise ValueError."""
+    meas = _make_meas_df(start=0.0, stop=1.0, step=0.01)
+    interp_times = np.array([2.0])
+    with pytest.raises(ValueError, match="tolerance"):
+        interpolate_measures(
+            meas_df=meas, meas_ts="sec", interp_ts=interp_times
+        )
+
+
+def test_gappy_data_raises():
+    """Interp point in a gap wider than tol raises ValueError."""
+    ts = np.concatenate([np.arange(0, 0.5, 0.01), np.arange(1.0, 1.5, 0.01)])
+    data = {"sec": ts, "F1": ts}
+    meas = pd.DataFrame(data)
+    interp_times = np.array([0.75])
+    with pytest.raises(ValueError, match="tolerance"):
+        interpolate_measures(
+            meas_df=meas, meas_ts="sec", interp_ts=interp_times, tol=0.01
+        )
+
+
+def test_gappy_data_large_tol_passes():
+    """Passes when tolerance is wide enough to cover the gap."""
+    ts = np.concatenate([np.arange(0, 0.5, 0.01), np.arange(1.0, 1.5, 0.01)])
+    data = {"sec": ts, "F1": ts}
+    meas = pd.DataFrame(data)
+    interp_times = np.array([0.75])
+    result = interpolate_measures(
+        meas_df=meas, meas_ts="sec", interp_ts=interp_times, tol=1.0
+    )
+    assert len(result) == 1
+
+
+def test_overwrite_true():
+    """overwrite=True allows overlapping column names."""
+    meas = _make_meas_df()
+    interp_df = pd.DataFrame({"obs_t": [0.1, 0.2], "F1": [999.0, 999.0]})
+    result = interpolate_measures(
+        meas_df=meas, meas_ts="sec",
+        interp_df=interp_df, interp_ts="obs_t",
+        overwrite=True,
+    )
+    np.testing.assert_allclose(result["F1"], [0.1, 0.2], atol=1e-10)
+
+
+def test_overwrite_false_raises_on_overlap():
+    """overwrite=False raises ValueError on column overlap."""
+    meas = _make_meas_df()
+    interp_df = pd.DataFrame({"obs_t": [0.1, 0.2], "F1": [999.0, 999.0]})
+    with pytest.raises(ValueError, match="overlap"):
+        interpolate_measures(
+            meas_df=meas, meas_ts="sec",
+            interp_df=interp_df, interp_ts="obs_t",
+            overwrite=False,
+        )
+
+
+def test_non_numeric_column_raises():
+    """Non-numeric column raises TypeError."""
+    df = pd.DataFrame({"sec": [0.0, 0.1, 0.2], "label": ["a", "b", "c"]})
+    interp_times = np.array([0.1])
+    with pytest.raises(TypeError, match="interpolate"):
+        interpolate_measures(
+            meas_df=df, meas_ts="sec", interp_ts=interp_times
+        )
+
+
+def test_non_increasing_meas_ts_raises():
+    """Non-increasing meas_ts raises ValueError."""
+    df = pd.DataFrame({"sec": [0.0, 0.2, 0.1], "F1": [0.0, 0.2, 0.1]})
+    interp_times = np.array([0.0])
+    with pytest.raises(ValueError, match="increasing"):
+        interpolate_measures(
+            meas_df=df, meas_ts="sec", interp_ts=interp_times
+        )
+
+
+def test_exact_boundary_values():
+    """Interp at first/last measurement time works."""
+    meas = _make_meas_df(start=0.0, stop=1.0, step=0.01)
+    first = meas["sec"].iloc[0]
+    last = meas["sec"].iloc[-1]
+    interp_times = np.array([first, last])
+    result = interpolate_measures(
+        meas_df=meas, meas_ts="sec", interp_ts=interp_times
+    )
+    np.testing.assert_allclose(result["F1"], [first, last], atol=1e-12)
+    np.testing.assert_allclose(result["F2"], [first * 2, last * 2], atol=1e-12)
+
+
+def test_interp_at_exact_measurement_times():
+    """Returns exact values with no interpolation error."""
+    meas = _make_meas_df()
+    exact_times = meas["sec"].iloc[[0, 10, 50, 100]].values
+    result = interpolate_measures(
+        meas_df=meas, meas_ts="sec", interp_ts=exact_times
+    )
+    np.testing.assert_allclose(result["F1"], exact_times, atol=1e-12)
+    np.testing.assert_allclose(result["F2"], exact_times * 2, atol=1e-12)
+
+
+def test_no_interp_df_overwrite_false():
+    """interp_df=None + overwrite=False should not crash."""
+    meas = _make_meas_df()
+    interp_times = np.array([0.05, 0.10])
+    result = interpolate_measures(
+        meas_df=meas, meas_ts="sec", interp_ts=interp_times, overwrite=False
+    )
+    assert len(result) == 2
+
+
+def test_error_message_with_numpy_interp_ts():
+    """ValueError message works when interp_ts is a numpy array."""
+    meas = _make_meas_df(start=0.0, stop=1.0, step=0.01)
+    interp_times = np.array([5.0])
+    with pytest.raises(ValueError, match="tolerance"):
+        interpolate_measures(
+            meas_df=meas, meas_ts="sec", interp_ts=interp_times
+        )


### PR DESCRIPTION
Noticed while running a script for @sande570 that there was huge memory usage of interpolate_measures.

Full disclosure, I didn't have time to fully diagnose myself and I don't know a ton about numpy, but did a claude vibe-root cause of the memory blowup, and it had a believable / reasonable explanation. Note: all code and aspects of the approach here are 100% claude-generated, so if that's frowned upon in this repo, let me know and instead I'll just open a bug report w.r.t. large memory usage.

If I understand correctly:
np.expand_dims(meas_ts, axis=0) - np.expand_dims(interp_ts, axis=1)

does a broadcast subtraction of a Nx1 and 1xM matrices, making a NxM matrix -- when we are interpolating values in really large samples (e.g. a few seconds of 30kHz audio), N becomes quite large, making this extremely memory intensive (hit 30GB of memory usage when I was running it)

IIUC what this is actually trying to measure is "distance to nearest timestamp", and the timestamps in meas_ts are ordered, so we can actually just go 1 by 1 through the interpolated points with binary search, rather than computing distance from all ts (and use way less memory -- more like O(M) total rather than O(NxM))

The commit named `Fix O(M×N) memory blowup in interpolate_measures` has the fix for that (as well as a few smaller fixes -- a type error in a format string on an error path and protection from a set of kwargs that used to error (interp_df=None + overwrite=False)).

Correctness validated by running a notebook with this code and verifying the output was unchanged, and by having claude write a bunch of unit test coverage.

Included also are 2 other commits, happy to drop them if you don't want them / want them to come in separately:
1) Add a bunch of pytest unit tests to verify the fix didn't change the functionality of the method.
2) Add a github action to run that test on PRs

These commits are also Claude generated, but helped me build trust that claude wasn't breaking existing logic + I thought it'd be nice into the future to have CI tests to protect against regressions. (Also just adding a bunch of tests revealed errors like the missing np.asarray in the error format string).