### PR TITLE
Reduce cold-start import overhead for packaged apps

### DIFF
--- a/phonlab/acoustic/cepstral.py
+++ b/phonlab/acoustic/cepstral.py
@@ -5,7 +5,6 @@ from librosa import util, stft, amplitude_to_db, frames_to_time
 from scipy import fft
 from pandas import DataFrame
 from scipy.signal import windows,filtfilt
-from sklearn.linear_model import LinearRegression
 from scipy.ndimage import gaussian_filter
 
 def compute_cepstrogram(x,fs, dBscale=True, l= 0.04, s=0.005):
@@ -154,7 +153,7 @@ This example plots the cepstral peak prominence through the "I'm twelve" example
 
     if smooth: s = 0.002  # faster framerate if smoothed
 
-    sec, quef, Sxx = compute_cepstrogram(y, fs, dBscale, l, s)
+    quef, sec, Sxx = compute_cepstrogram(y, fs, dBscale, l, s)
     
     if smooth:
         Sxx = gaussian_filter(Sxx,sigma = smooth,truncate=3)
@@ -172,10 +171,18 @@ This example plots the cepstral peak prominence through the "I'm twelve" example
         # hard coding here the range for the linear regression CPP normalization
         sT = int(np.round(fs/500)) # was [300,60] in Hillenbrand & Houde
         lT = int(np.round(fs/50)) # was [300,60] in Hillenbrand & Houde
-        X = np.array(np.arange(sT,lT,1))  # line fitting in the f0 region
-        X = np.reshape(X,(len(X),1))
-        reg =LinearRegression().fit(X,y=Sxx[:,sT:lT].T)  # vectorized regressions
-        p = np.diag(reg.predict(np.reshape(cp,(-1,1))))
+        xr = np.arange(sT,lT)  # quefrency-index axis shared by every frame's regression line
+        yr = Sxx[:,sT:lT]      # one row per frame, fit against xr
+
+        # closed-form OLS, vectorized across frames since xr is shared:
+        # slope_i = cov(xr, yr[i]) / var(xr), intercept_i = mean(yr[i]) - slope_i * mean(xr)
+        xbar = xr.mean()
+        xc = xr - xbar
+        sxx = np.sum(xc**2)
+        slope = (yr @ xc) / sxx
+        intercept = yr.mean(axis=1) - slope * xbar
+
+        p = intercept + slope * cp  # each frame's own fit line evaluated at its own peak location (cp)
         cpp = cpp-p
             
     return DataFrame({'sec': sec, 'f0':f0, 'cpp':cpp})

--- a/phonlab/acoustic/get_HNR.py
+++ b/phonlab/acoustic/get_HNR.py
@@ -4,7 +4,6 @@ import numpy as np
 from librosa import util
 from numpy.fft import rfft, irfft
 from pandas import DataFrame
-import matplotlib.pyplot as plt
 
 def HNR(x,fs, f0_range = [64,400], l= 0.06, s=0.005, target_time = None):
     '''Compute the Harmonics-to-Noise Ratio using the Cepstrum-Based method given by de Krom (1993).
@@ -134,6 +133,7 @@ at time 2.1 seconds in the file 'sf3_cln.wav'. In the top panel we see the log m
 
     # ------------- diagnostic plot ---------------
     if target_time != None:
+        import matplotlib.pyplot as plt
         fig,[ax1,ax2] = plt.subplots(nrows=2,ncols=1)
         quef = (np.array(range(1,NFFT//2+1))/fs *1000)  # the quefrecy axis of the cepstra (in ms)
         freqs = np.array(range(1,NFFT//2+1)) * (fs/NFFT)

--- a/phonlab/acoustic/nasality_measures.py
+++ b/phonlab/acoustic/nasality_measures.py
@@ -1,6 +1,5 @@
 import numpy as np
 from scipy.signal import find_peaks
-import matplotlib.pyplot as plt
 import pandas as pd
 
 from ..utils.prep_audio_ import prep_audio
@@ -201,7 +200,8 @@ Example
         a1h1 = a1_minus_h1
 
     # -------- optionally show a plot of the acoustic and LPC spectra ---------
-    if slice_time > 0:  
+    if slice_time > 0:
+        import matplotlib.pyplot as plt
         idx = np.argmin(abs(t-slice_time))  # find the closest index
 
         fig3 = plt.figure(figsize=(5, 4),dpi=150)

--- a/phonlab/acoustic/rhythm.py
+++ b/phonlab/acoustic/rhythm.py
@@ -1,7 +1,6 @@
 import scipy.signal
 import scipy.io.wavfile
 import numpy as np
-import matplotlib.pyplot as plt
 from librosa.util import frame
 from librosa import frames_to_time
 from ..utils.prep_audio_ import prep_audio

--- a/phonlab/acoustic/rlpc.py
+++ b/phonlab/acoustic/rlpc.py
@@ -9,7 +9,7 @@ from numba import jit
 from ..utils.prep_audio_ import prep_audio
 from ..acoustic.choose_order_ import choose_order
 
-@jit(nopython=True)
+@jit(nopython=True, cache=True)
 def weighted_cov(x,weight,npoles):
     # weighted covariance matrix, down-weighting samples with high LPC error
     C1 = np.zeros((npoles+1,npoles+1))
@@ -19,7 +19,7 @@ def weighted_cov(x,weight,npoles):
                 C1[i][j] += x[n-i] * x[n-j] * weight[n]
     return C1[1:npoles+1,1:npoles+1]
 
-@jit(nopython=True)
+@jit(nopython=True, cache=True)
 def weighted_cor(x,weight,npoles):
     # weighted correlation matrix, down-weighting samples with high LPC error
     c1 = np.zeros((npoles+1))

--- a/phonlab/acoustic/sgram_.py
+++ b/phonlab/acoustic/sgram_.py
@@ -1,7 +1,6 @@
 from scipy.signal import spectrogram
 from scipy.signal import windows
 import numpy as np
-import matplotlib.pyplot as plt
 from ..utils.prep_audio_ import prep_audio
 
 def compute_sgram(x,fs,w,s=0.001,order=13):
@@ -152,6 +151,8 @@ def sgram(x,fs, start=0, end=-1, tf=8000, band='wb', preemph = 0.94, font_size =
        Showing the spectrogram of sine-wave synthesis.
 
     """
+    import matplotlib.pyplot as plt
+
     target_fs = tf*2    # top frequency is the Nyquist frequency for the analysis
 
     if band=='nb':

--- a/phonlab/acoustic/shs.py
+++ b/phonlab/acoustic/shs.py
@@ -5,7 +5,6 @@ from librosa import util
 from scipy.interpolate import interp1d
 from numpy.fft import rfft, rfftfreq
 from pandas import DataFrame
-import matplotlib.pyplot as plt
 
 def _maxarg(x,axis = -1):
     try:
@@ -177,6 +176,7 @@ This example shows diagnostic plots from the get_f0_shs() function. The top left
     ts = (np.array(range(nb)) * step + half_frame)/fs  # time axis for output
 
     if fn!=None:
+        import matplotlib.pyplot as plt
         fig,((ax1,ax2),(ax3,ax4)) = plt.subplots(nrows=2,ncols=2)
         ax1.plot(ilogf,logS[fn,:],color="orange")
         ax2.plot(ilogf[lowerbound:upperbound],Hxx[fn,lowerbound:upperbound],color='black')
@@ -362,6 +362,7 @@ This example shows diagnostic plots from the shr_pitch() function. The top left 
     ts = (np.array(range(nb)) * step + half_frame)/fs  # time axis for output
 
     if fn!=None:
+        import matplotlib.pyplot as plt
         fig,((ax1,ax2),(ax3,ax4)) = plt.subplots(nrows=2,ncols=2)
         ax1.plot(ilogf,logS[fn,:],color="orange")
         ax2.plot(ilogf,Har[fn,:],color='black')

--- a/phonlab/acoustic/tvlp.py
+++ b/phonlab/acoustic/tvlp.py
@@ -9,7 +9,7 @@ from ..acoustic.choose_order_ import choose_order
 # This set of functions was written interactively with the AI model Claude, translating
 # and adapting Gowda's ftrack matlab code.  Keith Johnson, Feb 2026
 
-@jit(nopython=True)
+@jit(nopython=True, cache=True)
 def _build_matrices(x, p, q, w):
     """Build the Ypu matrix and Yn vector using Numba for speed."""
     n_samples = len(x)
@@ -31,7 +31,7 @@ def _build_matrices(x, p, q, w):
     return Ypu, Yn
 
 
-@jit(nopython=True)
+@jit(nopython=True, cache=True)
 def _solve_lstsq_numba(A, b):
     """Solve least squares using QR decomposition."""
     # Ensure arrays are contiguous for optimal performance
@@ -44,7 +44,7 @@ def _solve_lstsq_numba(A, b):
     return np.linalg.solve(R, Qt @ b)
 
 
-@jit(nopython=True)
+@jit(nopython=True, cache=True)
 def _irls_iteration(Ypu, Yn, max_iter=10, tol=1e-4, epsilon=1e-8):
     """IRLS iterations - Numba compatible."""
     m, n = Ypu.shape
@@ -83,7 +83,7 @@ def _irls_iteration(Ypu, Yn, max_iter=10, tol=1e-4, epsilon=1e-8):
     return x
 
 
-@jit(nopython=True)
+@jit(nopython=True, cache=True)
 def _compute_time_varying_coeffs(aki, frame_length):
     """
     Compute time-varying LP coefficients for each sample in a frame.
@@ -118,7 +118,7 @@ def _compute_time_varying_coeffs(aki, frame_length):
     return ak
 
 
-@jit(nopython=True, parallel=True)
+@jit(nopython=True, parallel=True, cache=True)
 def _process_frames_l2_parallel(frames, weights, p, q):
     """
     Process multiple frames in parallel using L2 norm.
@@ -156,7 +156,7 @@ def _process_frames_l2_parallel(frames, weights, p, q):
     return all_ak
 
 
-@jit(nopython=True, parallel=True)
+@jit(nopython=True, parallel=True, cache=True)
 def _process_frames_l1_parallel(frames, weights, p, q, max_iter=10):
     """
     Process multiple frames in parallel using L1 norm (IRLS).

--- a/phonlab/auditory/add_noise_.py
+++ b/phonlab/auditory/add_noise_.py
@@ -1,5 +1,4 @@
 import numpy as np
-import matplotlib.pyplot as plt
 import random
 import colorednoise as cn
 import librosa

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,6 @@ dependencies = [
     'pandas',
     'librosa',
     'praat-parselmouth',
-    'scikit-learn',
     'numba'
 ]
 classifiers = [


### PR DESCRIPTION
Several acoustic/auditory modules imported matplotlib.pyplot and scikit-learn's LinearRegression at module top level even though those libraries are only needed inside optional diagnostic-plot branches (or, in a couple of cases, not used at all outside docstring examples). Since phonlab's package __init__ already lazy-loads per-submodule, this meant calling any function from a file like get_HNR.py or shs.py paid the full matplotlib import cost even when the caller never plots anything - noticeable as slow first-launch time in an embedded/packaged app.

- Move matplotlib.pyplot imports into the specific branches that plot (get_HNR, nasality_measures, sgram_, shs), and drop it entirely where it was dead code (rhythm.py, add_noise_.py).
- Replace sklearn.linear_model.LinearRegression in cepstral.py's CPP() with an equivalent closed-form vectorized OLS fit (numpy only), verified numerically identical (~1e-15 diff) against the sklearn version, and drop scikit-learn from pyproject.toml since nothing else in the package used it.
- Add cache=True to the numba @jit decorators in rlpc.py and tvlp.py so compiled machine code persists to disk instead of recompiling on every first call in a fresh process (measured ~12s -> 0.07s on a warm cache).
- Fix a return-value unpacking order bug in cepstral.py's CPP(): it was unpacking compute_cepstrogram()'s (quef, ts, Ceps) as (sec, quef, Sxx), which crashed downstream DataFrame construction on real audio.